### PR TITLE
CAM-7974 default behavior of xml parser changed

### DIFF
--- a/src/main/java/org/camunda/bpm/model/xml/impl/parser/AbstractModelParser.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/parser/AbstractModelParser.java
@@ -56,6 +56,7 @@ public abstract class AbstractModelParser {
     dbf.setIgnoringComments(false);
     dbf.setIgnoringElementContentWhitespace(false);
     dbf.setNamespaceAware(true);
+    dbf.setExpandEntityReferences(false);
   }
 
   public ModelInstance parseModelFromStream(InputStream inputStream) {


### PR DESCRIPTION
Change default behavior of XML parser to: Do not expand entity references.

See Jira Ticket CAM-7974 for details.