### PR TITLE
Add possibility to disable references update for changed attributes

### DIFF
--- a/src/main/java/org/camunda/bpm/model/xml/ModelInstance.java
+++ b/src/main/java/org/camunda/bpm/model/xml/ModelInstance.java
@@ -61,6 +61,16 @@ public interface ModelInstance {
   <T extends ModelElementInstance> T newInstance(Class<T> type);
 
   /**
+   * Creates a new instance of type class with user-defined id.
+   *
+   * @param type  the class of the type to create
+   * @param id    identifier of new element instance
+   * @param <T>   instance type
+   * @return the new created instance
+   */
+  <T extends ModelElementInstance> T newInstance(Class<T> type, String id);
+
+  /**
    * Creates a new instance of type.
    *
    * @param type  the type to create
@@ -68,6 +78,16 @@ public interface ModelInstance {
    * @return the new created instance
    */
   <T extends ModelElementInstance> T newInstance(ModelElementType type);
+
+  /**
+   * Creates a new instance of type with user-defined id.
+   *
+   * @param type  the type to create
+   * @param id    identifier of new element instance
+   * @param <T>   instance type
+   * @return  the new created instance
+   */
+  <T extends ModelElementInstance> T newInstance(ModelElementType type, String id);
 
   /**
    * Returns the underlying model.

--- a/src/main/java/org/camunda/bpm/model/xml/impl/ModelInstanceImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/ModelInstanceImpl.java
@@ -69,18 +69,30 @@ public class ModelInstanceImpl implements ModelInstance {
   }
 
   public <T extends ModelElementInstance> T newInstance(Class<T> type) {
+    return newInstance(type, null);
+  }
+
+  public <T extends ModelElementInstance> T newInstance(Class<T> type, String id) {
     ModelElementType modelElementType = model.getType(type);
     if(modelElementType != null) {
-      return newInstance(modelElementType);
+      return newInstance(modelElementType, id);
     } else {
       throw new ModelException("Cannot create instance of ModelType "+type+": no such type registered.");
     }
   }
 
-  @SuppressWarnings("unchecked")
   public <T extends ModelElementInstance> T newInstance(ModelElementType type) {
+    return newInstance(type, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends ModelElementInstance> T newInstance(ModelElementType type, String id) {
     ModelElementInstance modelElementInstance = type.newInstance(this);
-    ModelUtil.setGeneratedUniqueIdentifier(type, modelElementInstance);
+    if (id != null && !id.isEmpty()) {
+      ModelUtil.setNewIdentifier(type, modelElementInstance, id, false);
+    } else {
+      ModelUtil.setGeneratedUniqueIdentifier(type, modelElementInstance);
+    }
     return (T) modelElementInstance;
   }
 
@@ -133,7 +145,6 @@ public class ModelInstanceImpl implements ModelInstance {
       return new ModelInstanceImpl(model, modelBuilder, document.clone());
   }
 
-  @Override
   public ValidationResults validate(Collection<ModelElementValidator<?>> validators) {
     return new ModelInstanceValidator(this, validators).validate();
   }

--- a/src/main/java/org/camunda/bpm/model/xml/impl/instance/ModelElementInstanceImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/instance/ModelElementInstanceImpl.java
@@ -93,10 +93,15 @@ public class ModelElementInstanceImpl implements ModelElementInstance {
   }
 
   public void setAttributeValue(String attributeName, String xmlValue) {
-    setAttributeValue(attributeName, xmlValue, false);
+    setAttributeValue(attributeName, xmlValue, false, true);
   }
 
   public void setAttributeValue(String attributeName, String xmlValue, boolean isIdAttribute) {
+    setAttributeValue(attributeName, xmlValue, isIdAttribute, true);
+  }
+
+  public void setAttributeValue(String attributeName, String xmlValue,
+                                boolean isIdAttribute, boolean withReferenceUpdate) {
     String oldValue = getAttributeValue(attributeName);
     if (isIdAttribute) {
       domElement.setIdAttribute(attributeName, xmlValue);
@@ -105,16 +110,21 @@ public class ModelElementInstanceImpl implements ModelElementInstance {
       domElement.setAttribute(attributeName, xmlValue);
     }
     Attribute<?> attribute = elementType.getAttribute(attributeName);
-    if (attribute != null) {
+    if (attribute != null && withReferenceUpdate) {
       ((AttributeImpl<?>) attribute).updateIncomingReferences(this, xmlValue, oldValue);
     }
   }
 
   public void setAttributeValueNs(String namespaceUri, String attributeName, String xmlValue) {
-    setAttributeValueNs(namespaceUri, attributeName, xmlValue, false);
+    setAttributeValueNs(namespaceUri, attributeName, xmlValue, false, true);
   }
 
   public void setAttributeValueNs(String namespaceUri, String attributeName, String xmlValue, boolean isIdAttribute) {
+    setAttributeValueNs(namespaceUri, attributeName, xmlValue, isIdAttribute, true);
+  }
+
+  public void setAttributeValueNs(String namespaceUri, String attributeName, String xmlValue,
+                                  boolean isIdAttribute, boolean withReferenceUpdate) {
     String namespaceForSetting = namespaceUri;
     if (hasValueToBeSetForAlternativeNs(namespaceUri, attributeName)) {
       namespaceForSetting = modelInstance.getModel().getAlternativeNamespace(namespaceUri);
@@ -127,7 +137,7 @@ public class ModelElementInstanceImpl implements ModelElementInstance {
       domElement.setAttribute(namespaceForSetting, attributeName, xmlValue);
     }
     Attribute<?> attribute = elementType.getAttribute(attributeName);
-    if (attribute != null) {
+    if (attribute != null && withReferenceUpdate) {
       ((AttributeImpl<?>) attribute).updateIncomingReferences(this, xmlValue, oldValue);
     }
   }

--- a/src/main/java/org/camunda/bpm/model/xml/impl/type/attribute/AttributeImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/type/attribute/AttributeImpl.java
@@ -108,11 +108,18 @@ public abstract class AttributeImpl<T> implements Attribute<T> {
    *  the value of the attribute.
    */
   public void setValue(ModelElementInstance modelElement, T value) {
+    setValue(modelElement, value, true);
+  }
+
+  public void setValue(ModelElementInstance modelElement, T value,
+                       boolean withReferenceUpdate) {
     String xmlValue = convertModelValueToXmlValue(value);
     if(namespaceUri == null) {
-      modelElement.setAttributeValue(attributeName, xmlValue, isIdAttribute);
+      modelElement.setAttributeValue(attributeName, xmlValue,
+              isIdAttribute, withReferenceUpdate);
     } else {
-      modelElement.setAttributeValueNs(namespaceUri, attributeName, xmlValue, isIdAttribute);
+      modelElement.setAttributeValueNs(namespaceUri, attributeName,
+              xmlValue, isIdAttribute, withReferenceUpdate);
     }
   }
 

--- a/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
@@ -33,6 +33,8 @@ import java.util.*;
  */
 public final class ModelUtil {
 
+  private final static String ID_ATTRIBUTE_NAME = "id";
+
   /**
    * Returns the {@link ModelElementInstanceImpl ModelElement} for a DOM element.
    * If the model element does not yet exist, it is created and linked to the DOM.
@@ -203,15 +205,32 @@ public final class ModelUtil {
   }
 
   /**
+   * Set new identifier if the type has a String id attribute
+   *
+   * @param type the type of the model element
+   * @param modelElementInstance the model element instance to set the id
+   * @param newId new identifier
+   * @param withReferenceUpdate true to update id references in other elements, false otherwise
+   */
+  public static void setNewIdentifier(ModelElementType type, ModelElementInstance modelElementInstance,
+                                   String newId, boolean withReferenceUpdate) {
+    Attribute<?> id = type.getAttribute(ID_ATTRIBUTE_NAME);
+    if (id != null && id instanceof StringAttribute && id.isIdAttribute()) {
+      modelElementInstance.setAttributeValue(ID_ATTRIBUTE_NAME, newId, true, withReferenceUpdate);
+    }
+  }
+
+  /**
    * Set unique identifier if the type has a String id attribute
    *
    * @param type the type of the model element
    * @param modelElementInstance the model element instance to set the id
    */
   public static void setGeneratedUniqueIdentifier(ModelElementType type, ModelElementInstance modelElementInstance) {
-    Attribute<?> id = type.getAttribute("id");
+    Attribute<?> id = type.getAttribute(ID_ATTRIBUTE_NAME);
     if (id != null && id instanceof StringAttribute && id.isIdAttribute()) {
-      ((StringAttribute) id).setValue(modelElementInstance, ModelUtil.getUniqueIdentifier(type));
+      String uniqueId = ModelUtil.getUniqueIdentifier(type);
+      modelElementInstance.setAttributeValue(ID_ATTRIBUTE_NAME, uniqueId, true, false);
     }
   }
 

--- a/src/main/java/org/camunda/bpm/model/xml/instance/ModelElementInstance.java
+++ b/src/main/java/org/camunda/bpm/model/xml/instance/ModelElementInstance.java
@@ -81,6 +81,17 @@ public interface ModelElementInstance {
   void setAttributeValue(String attributeName, String xmlValue, boolean isIdAttribute);
 
   /**
+   * Sets attribute value by name.
+   *
+   * @param attributeName  the name of the attribute
+   * @param xmlValue  the value to set
+   * @param isIdAttribute  true if the attribute is an ID attribute, false otherwise
+   * @param withReferenceUpdate  true to update incoming references in other elements, false otherwise
+   */
+  void setAttributeValue(String attributeName, String xmlValue,
+                         boolean isIdAttribute, boolean withReferenceUpdate);
+
+  /**
    * Removes attribute by name.
    *
    * @param attributeName  the name of the attribute
@@ -114,6 +125,18 @@ public interface ModelElementInstance {
    * @param isIdAttribute  true if the attribute is an ID attribute, false otherwise
    */
   void setAttributeValueNs(String namespaceUri, String attributeName, String xmlValue, boolean isIdAttribute);
+
+  /**
+   * Sets the attribute value by name and namespace.
+   *
+   * @param namespaceUri  the namespace URI of the attribute
+   * @param attributeName  the name of the attribute
+   * @param xmlValue  the XML value to set
+   * @param isIdAttribute  true if the attribute is an ID attribute, false otherwise
+   * @param withReferenceUpdate  true to update incoming references in other elements, false otherwise
+   */
+  void setAttributeValueNs(String namespaceUri, String attributeName, String xmlValue,
+                           boolean isIdAttribute, boolean withReferenceUpdate);
 
   /**
    * Removes the attribute by name and namespace.


### PR DESCRIPTION
I propose to let users to change attribute values without updating references. This can allow performance improvements in certain sutuation, for example, setting initial IDs for newly created elements. See this [issue](https://github.com/camunda/camunda-xml-model/issues/4) for more information.

I added new methods with additional parameter `withReferenceUpdate`:
* `setAttributeValue` and `setAttributeValue` in **ModelElementInstanceImpl.java**;
* `setValue` in **AttributeImpl.java**;
* `setNewIdentifier` helper in **ModelUtil.java**.

References update is disabled in this cases:
* setting generated UUID for model element (`setGeneratedUniqueIdentifier` function in **ModelUtil.java**);
* setting user-defined ID for model element (`newInstance` function in **ModelInstanceImpl.java**).