### PR TITLE
Skip the lookup for the 'ModelElementType' when finding elements

### DIFF
--- a/src/main/java/org/camunda/bpm/model/xml/impl/type/ModelElementTypeImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/type/ModelElementTypeImpl.java
@@ -236,7 +236,7 @@ public class ModelElementTypeImpl implements ModelElementType {
 
     List<ModelElementInstance> resultList = new ArrayList<ModelElementInstance>();
     for (DomElement element : elements) {
-      resultList.add(ModelUtil.getModelElement(element, modelInstanceImpl));
+      resultList.add(ModelUtil.getModelElement(element, modelInstanceImpl, this));
     }
     return resultList;
   }

--- a/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
@@ -52,6 +52,17 @@ public final class ModelUtil {
     return modelElement;
   }
 
+  public static ModelElementInstance getModelElement(DomElement domElement, ModelInstanceImpl modelInstance, ModelElementTypeImpl modelType) {
+    ModelElementInstance modelElement = domElement.getModelElementInstance();
+
+    if(modelElement == null) {
+
+      modelElement = modelType.newInstance(modelInstance, domElement);
+      domElement.setModelElementInstance(modelElement);
+    }
+    return modelElement;
+  }
+
   protected static ModelElementTypeImpl getModelElement(DomElement domElement, ModelInstanceImpl modelInstance, String namespaceUri) {
     String localName = domElement.getLocalName();
     ModelElementTypeImpl modelType = (ModelElementTypeImpl) modelInstance.getModel().getTypeForName(namespaceUri, localName);


### PR DESCRIPTION
Skip the lookup for the 'ModelElementType' in the main `typesByName` Map in the `ModelImpl` class when getting model elements by type from a model, as the 'ModelElementType' is already know beforehand from the type requested.

In addition it also fixes the specific issue outlined here: https://forum.camunda.org/t/query-dmn-model/5414 . Although this is not a general fix for that issue present, it still brings a positive side effect with it. The more general fix can be found at #7 .

