### PR TITLE
CAM-8888 Added optional schema type information to the ModelElementType for duplicate names

### DIFF
--- a/src/main/java/org/camunda/bpm/model/xml/Model.java
+++ b/src/main/java/org/camunda/bpm/model/xml/Model.java
@@ -60,6 +60,19 @@ public interface Model {
   ModelElementType getTypeForName(String namespaceUri, String typeName);
 
   /**
+   * Gets the defined {@link ModelElementType} for a type by its name, namespace URI, schema type and schema namespace URI.
+   *
+   *
+   * @param namespaceUri the namespace URI for the type
+   * @param typeName the name of the type
+   * @param schemaNamespaceUri the namespace URI for the schema type
+   * @param schemaTypeName the name of the schema type
+   * @return the element type or null if no type is defined for the name and namespace URI
+   */
+  ModelElementType getTypeForNameAndSchemaType(String namespaceUri, String typeName,
+                                               String schemaNamespaceUri, String schemaTypeName);
+
+  /**
    * Returns the model name, which is the identifier of this model.
    *
    * @return the model name

--- a/src/main/java/org/camunda/bpm/model/xml/impl/instance/DomElementImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/instance/DomElementImpl.java
@@ -44,7 +44,7 @@ public class DomElementImpl implements DomElement {
     this.document = element.getOwnerDocument();
   }
 
-  protected Element getElement() {
+  public Element getElement() {
     return element;
   }
 

--- a/src/main/java/org/camunda/bpm/model/xml/impl/type/ModelElementTypeBuilderImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/type/ModelElementTypeBuilderImpl.java
@@ -62,6 +62,16 @@ public class ModelElementTypeBuilderImpl implements ModelElementTypeBuilder, Mod
     return this;
   }
 
+  public ModelElementTypeBuilder schemaTypeName(String schemaTypeName) {
+    modelType.setSchemaTypeName(schemaTypeName);
+    return this;
+  }
+
+  public ModelElementTypeBuilder schemaTypeNamespaceUri(String schemaNamespaceUri) {
+    modelType.setSchemaTypeNamespace(schemaNamespaceUri);
+    return this;
+  }
+
   public AttributeBuilder<Boolean> booleanAttribute(String attributeName) {
     BooleanAttributeBuilder builder = new BooleanAttributeBuilder(attributeName, modelType);
     modelBuildOperations.add(builder);

--- a/src/main/java/org/camunda/bpm/model/xml/impl/type/ModelElementTypeImpl.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/type/ModelElementTypeImpl.java
@@ -12,13 +12,6 @@
  */
 package org.camunda.bpm.model.xml.impl.type;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.camunda.bpm.model.xml.Model;
 import org.camunda.bpm.model.xml.ModelException;
 import org.camunda.bpm.model.xml.ModelInstance;
@@ -35,6 +28,8 @@ import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder.ModelTypeInstanceP
 import org.camunda.bpm.model.xml.type.attribute.Attribute;
 import org.camunda.bpm.model.xml.type.child.ChildElementCollection;
 
+import java.util.*;
+
 /**
  * @author Daniel Meyer
  *
@@ -50,6 +45,10 @@ public class ModelElementTypeImpl implements ModelElementType {
   private String typeNamespace;
 
   private ModelElementTypeImpl baseType;
+
+  private String schemaTypeName;
+
+  private String schemaTypeNamespace;
 
   private final List<ModelElementType> extendingTypes = new ArrayList<ModelElementType>();
 
@@ -132,6 +131,22 @@ public class ModelElementTypeImpl implements ModelElementType {
 
   public String getTypeNamespace() {
     return typeNamespace;
+  }
+
+  public void setSchemaTypeName(String schemaTypeName) {
+    this.schemaTypeName = schemaTypeName;
+  }
+
+  public String getSchemaTypeName() {
+    return schemaTypeName;
+  }
+
+  public void setSchemaTypeNamespace(String schemaTypeNamespace) {
+    this.schemaTypeNamespace = schemaTypeNamespace;
+  }
+
+  public String getSchemaTypeNamespace() {
+    return schemaTypeNamespace;
   }
 
   public void setBaseType(ModelElementTypeImpl baseType) {

--- a/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
@@ -83,6 +83,10 @@ public final class ModelUtil {
     return new QName(namespaceUri, localName);
   }
 
+  public static QName getQName(String namespaceUri, String localName, String schemaNamespaceUri, String schemaTypeName) {
+    return new QName(namespaceUri, localName, schemaNamespaceUri, schemaTypeName);
+  }
+
   public static void ensureInstanceOf(Object instance, Class<?> type) {
     if(!type.isAssignableFrom(instance.getClass())) {
       throw new ModelException("Object is not instance of type "+type.getName());

--- a/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelUtil.java
@@ -15,6 +15,7 @@ package org.camunda.bpm.model.xml.impl.util;
 import org.camunda.bpm.model.xml.Model;
 import org.camunda.bpm.model.xml.ModelException;
 import org.camunda.bpm.model.xml.impl.ModelInstanceImpl;
+import org.camunda.bpm.model.xml.impl.instance.DomElementImpl;
 import org.camunda.bpm.model.xml.impl.instance.ModelElementInstanceImpl;
 import org.camunda.bpm.model.xml.impl.type.ModelElementTypeImpl;
 import org.camunda.bpm.model.xml.impl.type.attribute.StringAttribute;
@@ -22,6 +23,7 @@ import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.type.ModelElementType;
 import org.camunda.bpm.model.xml.type.attribute.Attribute;
+import org.w3c.dom.TypeInfo;
 
 import java.util.*;
 
@@ -53,8 +55,13 @@ public final class ModelUtil {
   }
 
   protected static ModelElementTypeImpl getModelElement(DomElement domElement, ModelInstanceImpl modelInstance, String namespaceUri) {
+
+    TypeInfo domElementTypeInfo = ((DomElementImpl) domElement).getElement().getSchemaTypeInfo();
+
     String localName = domElement.getLocalName();
-    ModelElementTypeImpl modelType = (ModelElementTypeImpl) modelInstance.getModel().getTypeForName(namespaceUri, localName);
+    ModelElementTypeImpl modelType = (ModelElementTypeImpl) modelInstance.getModel()
+            .getTypeForNameAndSchemaType(namespaceUri, localName,
+                    domElementTypeInfo.getTypeNamespace(), domElementTypeInfo.getTypeName());
 
     if (modelType == null) {
 
@@ -244,5 +251,4 @@ public final class ModelUtil {
   public static String getUniqueIdentifier(ModelElementType type) {
     return type.getTypeName() + "_" + UUID.randomUUID();
   }
-
 }

--- a/src/main/java/org/camunda/bpm/model/xml/impl/util/QName.java
+++ b/src/main/java/org/camunda/bpm/model/xml/impl/util/QName.java
@@ -20,14 +20,22 @@ public class QName {
 
   private final String qualifier;
   private final String localName;
+  private final String schemaQualifier;
+  private final String schemaLocalName;
 
   public QName(String localName) {
     this(null, localName);
   }
 
   public QName(String qualifier, String localName) {
-    this.localName = localName;
+    this(qualifier, localName, null, null);
+  }
+
+  public QName(String qualifier, String localName, String schemaQualifier, String schemaLocalName) {
     this.qualifier = qualifier;
+    this.localName = localName;
+    this.schemaQualifier = schemaQualifier;
+    this.schemaLocalName = schemaLocalName;
   }
 
   public String getQualifier() {
@@ -74,6 +82,8 @@ public class QName {
     int result = 1;
     result = prime * result + ((localName == null) ? 0 : localName.hashCode());
     result = prime * result + ((qualifier == null) ? 0 : qualifier.hashCode());
+    result = prime * result + ((schemaLocalName == null) ? 0 : schemaLocalName.hashCode());
+    result = prime * result + ((schemaQualifier == null) ? 0 : schemaQualifier.hashCode());
     return result;
   }
 
@@ -101,6 +111,20 @@ public class QName {
         return false;
       }
     } else if (!qualifier.equals(other.qualifier)) {
+      return false;
+    }
+    if (schemaLocalName == null) {
+      if (other.schemaLocalName != null) {
+        return false;
+      }
+    } else if (!schemaLocalName.equals(other.schemaLocalName)) {
+      return false;
+    }
+    if (schemaQualifier == null) {
+      if (other.schemaQualifier != null) {
+        return false;
+      }
+    } else if (!schemaQualifier.equals(other.schemaQualifier)) {
       return false;
     }
     return true;

--- a/src/main/java/org/camunda/bpm/model/xml/type/ModelElementType.java
+++ b/src/main/java/org/camunda/bpm/model/xml/type/ModelElementType.java
@@ -30,6 +30,10 @@ public interface ModelElementType {
 
   String getTypeNamespace();
 
+  String getSchemaTypeName();
+
+  String getSchemaTypeNamespace();
+
   Class<? extends ModelElementInstance> getInstanceType();
 
   List<Attribute<?>> getAttributes();

--- a/src/main/java/org/camunda/bpm/model/xml/type/ModelElementTypeBuilder.java
+++ b/src/main/java/org/camunda/bpm/model/xml/type/ModelElementTypeBuilder.java
@@ -25,6 +25,10 @@ public interface ModelElementTypeBuilder {
 
   ModelElementTypeBuilder namespaceUri(String namespaceUri);
 
+  ModelElementTypeBuilder schemaTypeName(String schemaTypeName);
+
+  ModelElementTypeBuilder schemaTypeNamespaceUri(String schemaNamespaceUri);
+
   ModelElementTypeBuilder extendsType(Class<? extends ModelElementInstance> extendedType);
 
   <T extends ModelElementInstance> ModelElementTypeBuilder instanceProvider(ModelTypeInstanceProvider<T> instanceProvider);


### PR DESCRIPTION
Added optional schema type information to the `ModelElementType` (and its builder) as an option to differentiate elements which have the same name (eg. dmn-model `InputData.class` and `InputDataReference.class`). 

In addition, added methods to the `ModelImpl` to find the `ModelElementType` instance based both the elements name and schema type.

This change is backward compatible with all existing code as the schema type information is optional. It should be added to elements which have the same name in the downstream projects (DMN, ...).

This addresses the issue found here: https://forum.camunda.org/t/query-dmn-model/5414 . It makes sure that not only lookups of elements by type (addressed and fixed as a side effect of #6 ), but also lookups of elements by ID (and potentially others) are processed and created correctly.